### PR TITLE
Fix crash in Gesture.m

### DIFF
--- a/Application/Gesture.m
+++ b/Application/Gesture.m
@@ -2626,8 +2626,6 @@ int attemptMT;
         //}
     }
 
-    CFRelease((CFMutableArrayRef)deviceList);
-
     if (!found && attemptMT < 3) {
         [NSTimer scheduledTimerWithTimeInterval:1.0 target:me selector:@selector(updateDevicesMT:) userInfo:nil repeats:NO];
         attemptMT++;


### PR DESCRIPTION
Remove a manual `CFRelease` that causes a EXC_BAD_ACCESS on leaving `updateDevicesMT:` because of over-releasing the `deviceList` array.
